### PR TITLE
Fixed margins missing in chat

### DIFF
--- a/hedvig-web/src/components/Chat.js
+++ b/hedvig-web/src/components/Chat.js
@@ -48,7 +48,7 @@ export default class Chat extends React.Component {
         />
         <div className="pure-g pure-centered">
           <div className="pure-u-1-1 pure-u-lg-2-3">
-            <div className="Chat__chat-area" style={{overflow: "hidden", height: "100%"}}>
+            <div className="Chat__chat-area">
               <MessageList />
             </div>
 

--- a/hedvig-web/src/components/chat.css
+++ b/hedvig-web/src/components/chat.css
@@ -4,8 +4,9 @@
 }
 
 .Chat__chat-area {
-  margin: 1em 0 0;
+  margin: 0.5em;
   overflow: hidden;
+  height: 100%;
   -ms-overflow-style: none;
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
On friday to quickly fix the chat in IE11 I converted everything quickly to PureCSS, I forgot to add back margins to make the chat not hug the walls on mobile. this commit fixes it

Also I removed some inline styling just cause