### PR TITLE
Fix asset tracker demo text size

### DIFF
--- a/hedvig-web/src/features/landing/sections/AssetTrackerDemo/assettrackerdemo.css
+++ b/hedvig-web/src/features/landing/sections/AssetTrackerDemo/assettrackerdemo.css
@@ -2,14 +2,12 @@
   margin: 2em 0 0;
 }
 
-
 .AssetTrackerDemo__text {
   text-align: center;
   display: flex;
   flex-direction: column;
   justify-content: center;
   height: 100%;
-  font-size: 14px;
   line-height: normal;
 }
 
@@ -57,7 +55,6 @@
 
   .AssetTrackerDemo__text {
     text-align: left;
-    font-size: 18px;
     margin: 0 0 0 2em;
   }
 


### PR DESCRIPTION
Change paragraph from 14px > 18px (inherit from pure-u-*)

Before:
<img width="684" alt="screen shot 2018-02-19 at 14 43 55" src="https://user-images.githubusercontent.com/20165/36380666-632f73e0-1583-11e8-9954-33e93f16ca9a.png">

After:
<img width="684" alt="screen shot 2018-02-19 at 14 43 42" src="https://user-images.githubusercontent.com/20165/36380669-662e13bc-1583-11e8-9ba5-7d31dfd68710.png">
