### PR TITLE
Add app mounted event > GTM > Intercom boot

### DIFF
--- a/hedvig-web/src/App.js
+++ b/hedvig-web/src/App.js
@@ -24,7 +24,7 @@ window.hedvigRedux = hedvigRedux
 window.Navigation = Navigation
 window.moment = moment
 
-if (process.env.NODE_ENV === "production") {
+if (process.env.NODE_ENV === 'production') {
   Raven.config('https://f3942dffb4a14ed0ab23aa38b6ae73f0@sentry.io/284598').install()
 }
 
@@ -48,6 +48,10 @@ class App extends Component {
   componentWillMount() {
     // this.store.dispatch(hedvigRedux.chatActions.getMessages())
     this.store.dispatch(hedvigRedux.chatActions.getAvatars())
+  }
+
+  componentDidMount() {
+    this.store.dispatch({type: "ANALYTICS/APP_MOUNTED"})
   }
 
   render() {

--- a/hedvig-web/src/middleware/analytics.js
+++ b/hedvig-web/src/middleware/analytics.js
@@ -17,9 +17,18 @@ const ctaClick = action => {
   }
 }
 
+const appMounted = action => {
+  return {
+    hitType: 'event',
+    eventCategory: 'app',
+    eventAction: 'mounted'
+  }
+}
+
 const eventsMap = {
   "@@router/LOCATION_CHANGE": pageView,
-  "ANALYTICS/CTA_CLICK": ctaClick
+  "ANALYTICS/CTA_CLICK": ctaClick,
+  "ANALYTICS/APP_MOUNTED": appMounted
 }
 
 const middleware = createMiddleware(eventsMap, GoogleTagManager())


### PR DESCRIPTION
Sending an app mounted event when the app mounts to GTM.
Triggering Intercom.boot() in GTM when this happens to make it
easier to toggle it on and off without re-deploying the app.

Intercom.update() is triggered on the pageview event, which looks
for new messages that should be displayed to the current user.