### PR TITLE
Remove chat restart after onboarded

### DIFF
--- a/hedvig-app/src/components/Chat.js
+++ b/hedvig-app/src/components/Chat.js
@@ -100,6 +100,7 @@ export default class Chat extends React.Component {
 
   render() {
     let headerLeft
+    let headerRight
     if (
       this.props.insurance.status === "INACTIVE" ||
       this.props.insurance.status === "ACTIVE"
@@ -107,19 +108,19 @@ export default class Chat extends React.Component {
       headerLeft = (
         <NavigateBackButton onPress={() => this.props.showDashboard()} />
       )
+    } else {
+      headerRight = (
+        <ChatNavRestartButton
+          onPress={() => this.props.resetConversation()}
+        />
+      )
     }
     return (
       <StyledChatContainer>
         <NavBar
           title="Hedvig"
-          headerLeft={
-            headerLeft
-          }
-          headerRight={
-            <ChatNavRestartButton
-              onPress={() => this.props.resetConversation()}
-            />
-          }
+          headerLeft={headerLeft}
+          headerRight={headerRight}
         />
         <StyledMessageAndResponseArea behaviour="padding">
           <StyledMessageArea>


### PR DESCRIPTION
Currently the chat restart kicks you out of the app if you're already
onboarded without an option to get back in (activation code already used).

This is a temprary measure until the restart works.