### PR TITLE
Change label for insurance status inactive

### DIFF
--- a/hedvig-app/src/components/dashboard/Dashboard.js
+++ b/hedvig-app/src/components/dashboard/Dashboard.js
@@ -79,7 +79,7 @@ export default class Dashboard extends React.Component {
     return {
       ACTIVE: "Aktiv",
       PENDING: "På gång",
-      INACTIVE: "Inaktiv",
+      INACTIVE: "Aktiveras snart",
     }[this.props.insurance.status]
   }
 


### PR DESCRIPTION
Currently `INACTIVE` means one of the following:
- Price quoted
- Signed with no activation date
- Signed but activation date in the future
- Terminated

Activation date is set in the future when we know when your old insurance
is terminated (if you don't have an insurance its set to now).

This PR is a temporary fix until we expose the new states and activationDate, terminationDate from the backend.