### PR TITLE
Feature/trustly success fail screens

### DIFF
--- a/hedvig-app/src/components/navigation/base.js
+++ b/hedvig-app/src/components/navigation/base.js
@@ -9,7 +9,7 @@ import ChatModal from "../../containers/navigation/ChatModal"
 import { Carousel } from "../Carousel"
 import { MyTabNavigator } from "./tabs"
 import AddEditAsset from "../../containers/asset-tracker/AddEditAsset"
-import Payment from "../Payment"
+import Payment from "../../features/payment"
 
 const HomeBaseNavigator = StackNavigator(
   {

--- a/hedvig-redux/src/sagas/index.js
+++ b/hedvig-redux/src/sagas/index.js
@@ -38,7 +38,7 @@ import { handleCheckoutSaga } from "./offer"
 import { handleEventSaga } from "./events"
 import { addListenerSaga } from "./listener"
 import runner from "./sagaRunner"
-import { startPaymentSaga } from "./payment";
+import { startPaymentSaga, finalizePaymentSaga } from "./payment";
 
 const root = (additionalSagas = []) =>
   function* rootSaga() {
@@ -66,6 +66,7 @@ const root = (additionalSagas = []) =>
       addListenerSaga,
       startWebChatSaga,
       startPaymentSaga,
+      finalizePaymentSaga,
       ...additionalSagas
     ])
   }

--- a/hedvig-redux/src/sagas/payment.js
+++ b/hedvig-redux/src/sagas/payment.js
@@ -1,22 +1,7 @@
 import { takeEvery, put, take } from "redux-saga/effects"
+import { getMessages } from "../actions/chat"
 
 const startPayment = function*(action) {
-  // This block only for development
-  /*
-  yield put({type: "API", payload: {
-    url: "/hedvig/trigger/_/createDDM",
-    method: "POST",
-    body: JSON.stringify({
-      ssn: '201212121212',
-      firstName: 'Test',
-      lastName: 'Testerson',
-      email: 'test@hedvig.com'
-    }),
-    headers: { 'Content-Type': 'application/json'},
-    SUCCESS: "PAYMENT/START_PAYMENT_SUCCESS"
-  }})
-  const res = yield take(["PAYMENT/START_PAYMENT_SUCCESS", "API_ERROR"])
-  */
   yield put({
     type: "API",
     payload: {
@@ -26,10 +11,29 @@ const startPayment = function*(action) {
       SUCCESS: "PAYMENT/RETRIEVE_IFRAME_URL"
     }
   })
-  const res2 = yield take(["PAYMENT/RETRIEVE_IFRAME_URL", "API_ERROR"])
-  yield put({type: "PAYMENT/RECEIVED_IFRAME_URL", payload: {url: res2.payload.url}})
+  const res = yield take(["PAYMENT/RETRIEVE_IFRAME_URL", "API_ERROR"])
+  yield put({type: "PAYMENT/RECEIVED_IFRAME_URL", payload: {url: res.payload.url}})
 }
 
-export const startPaymentSaga = function* (){
+const finalizePayment = function*(action) {
+  yield put({
+    type: "API",
+    payload: {
+      url: "/hedvig/trustlyClosed",
+      method: "POST",
+      SUCCESS: "PAYMENT/FINALIZE_PAYMENT_SUCCESS"
+    }
+  })
+
+  yield take(["PAYMENT/FINALIZE_PAYMENT_SUCCESS", "API_ERROR"])
+  yield put(getMessages())
+  return action.payload.onFinish()
+}
+
+export const startPaymentSaga = function*() {
   yield takeEvery("PAYMENT/REQUEST_PAYMENT_REGISTRATION", startPayment)
+}
+
+export const finalizePaymentSaga = function*() {
+  yield takeEvery(["PAYMENT/ON_PAYMENT_SUCCESS", "PAYMENT/ON_PAYMENT_FAILURE", "PAYMENT/CANCEL_PAYMENT"], finalizePayment)
 }


### PR DESCRIPTION
Handle redirects back to the chat from our hosted trustly success|failure redirect pages.

Trustly user flow
1. User clicks setup payment in Chat > calls backend with redirect url
   set to hedvig.com/trustly/payment-success|failure on website
2. Render trustly url in Webview > user goes through payment flow
3. Trustly redirects to above redirect url which renderes a success page
   with a deep link which is handled from `handleAllDeepLinks`