### PR TITLE
Handle message with no responsePath

### DIFF
--- a/hedvig-redux/src/sagas/chat.js
+++ b/hedvig-redux/src/sagas/chat.js
@@ -37,7 +37,7 @@ const sendChatResponse = function*({ payload: { message, bodyOverride } }) {
     type: API,
     payload: {
       method: "POST",
-      url: messageFromState.header.responsePath,
+      url: "/response",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(messageFromState, null, 4),
       SUCCESS: "SEND_CHAT_RESPONSE_SUCCESS"
@@ -58,7 +58,6 @@ const sendChatResponse = function*({ payload: { message, bodyOverride } }) {
 const sendChatResponseSaga = function*() {
   yield takeEvery(SEND_CHAT_RESPONSE, sendChatResponse)
 }
-
 
 const startWebChat = function*() {
   yield put({
@@ -197,7 +196,7 @@ const getInsuranceWithMessages = function*() {
 
 const getInsuranceWithMessagesSaga = function*() {
   yield takeEvery(API, function*(apiAction) {
-    if (apiAction.payload.url.includes(chatActions.GET_MESSAGES_URL)) {
+    if (apiAction.payload && apiAction.payload.url.includes(chatActions.GET_MESSAGES_URL)) {
       yield getInsuranceWithMessages(apiAction)
     }
   })


### PR DESCRIPTION
Fixing: https://sentry.io/hedvig/hedvig-app/issues/475492285/activity/

Currently the backend always sets responsePath to /response on messages,
this is used when POSTing a response from the chat.

We should hardcode this on the front end until we need this functionality
to make debugging and tracability easier in the codebase.