### PR TITLE
Move sticky headers on home and profile to scroll

### DIFF
--- a/hedvig-app/src/components/Link.js
+++ b/hedvig-app/src/components/Link.js
@@ -9,8 +9,7 @@ const TextLink = ({ to, children }) => (
       textDecorationLine: "underline",
       lineHeight: 24,
     }}
-    onPress={() => Linking.openURL(to)}
-  >
+    onPress={() => Linking.openURL(to)}>
     {children}
   </Text>
 )

--- a/hedvig-app/src/components/Link.js
+++ b/hedvig-app/src/components/Link.js
@@ -7,9 +7,8 @@ const TextLink = ({ to, children }) => (
     style={{
       color: "#555555",
       textDecorationLine: "underline",
-      lineHeight: 24
+      lineHeight: 24,
     }}
-    hitSlop={{top: 20, bottom: 20, left: 14, right: 14}}
     onPress={() => Linking.openURL(to)}
   >
     {children}

--- a/hedvig-app/src/components/Profile.js
+++ b/hedvig-app/src/components/Profile.js
@@ -193,19 +193,19 @@ export default class Profile extends React.Component {
   render() {
     return (
       <StyledProfileContainer>
-        <StyledListHeader>
-          <StyledCharityImage
-            source={{ uri: this.props.user.selectedCashbackImageUrl }}
-            resizeMode="center"
-          />
-          <StyledCharityParagraph>
-            {this.props.user.selectedCashbackParagraph}
-          </StyledCharityParagraph>
-          <StyledCharitySignature>
-            {this.props.user.selectedCashbackSignature}
-          </StyledCharitySignature>
-        </StyledListHeader>
         <StyledList>
+          <StyledListHeader>
+            <StyledCharityImage
+              source={{ uri: this.props.user.selectedCashbackImageUrl }}
+              resizeMode="center"
+            />
+            <StyledCharityParagraph>
+              {this.props.user.selectedCashbackParagraph}
+            </StyledCharityParagraph>
+            <StyledCharitySignature>
+              {this.props.user.selectedCashbackSignature}
+            </StyledCharitySignature>
+          </StyledListHeader>
           {this._maybeUserInfo()}
           <RoundedButton title="Logga ut" onPress={() => this.props.logout()} style={{marginTop: 8, marginBottom: 24}}/>
         </StyledList>

--- a/hedvig-app/src/components/dashboard/Dashboard.js
+++ b/hedvig-app/src/components/dashboard/Dashboard.js
@@ -7,14 +7,17 @@ import { PerilsCategory } from "./PerilsCategory"
 
 import { RoundedButton } from "../Button"
 import {
+  StyledDashboardHeaderOffWhite,
+  StyledDashboardHeaderRowLessMargin,
+  StyledDashboardHeaderItem,
   StyledDashboardContainer,
   StyledCategoriesContainer,
   StyledCheckoutButton,
   StyledDashboardHeaderIcon,
   StyledConditionRow
 } from "../styles/dashboard"
-import { StyledPassiveText } from "../styles/text"
-import DashboardHeader from "./DashboardHeader"
+import { StyledPassiveText, StyledHeading } from "../styles/text"
+
 import { INSURANCE_TYPES } from "../../constants"
 
 export default class Dashboard extends React.Component {
@@ -74,20 +77,20 @@ export default class Dashboard extends React.Component {
     }[this.props.insurance.status]
   }
 
-  header() {
-    return (
-      <DashboardHeader
-        statusIcon={this.statusIcon.bind(this)}
-        statusText={this.statusText.bind(this)}
-      />
-    )
-  }
-
   render() {
     return (
       <StyledDashboardContainer style={{ flex: 1 }}>
-        {this.header()}
         <ScrollView style={{ flex: 1 }}>
+          <StyledDashboardHeaderOffWhite>
+            <StyledDashboardHeaderRowLessMargin>
+              <StyledHeading>Min hemförsäkring</StyledHeading>
+              <StyledDashboardHeaderItem>
+                {this.statusIcon()}
+                <StyledPassiveText>{this.statusText()}</StyledPassiveText>
+              </StyledDashboardHeaderItem>
+            </StyledDashboardHeaderRowLessMargin>
+          </StyledDashboardHeaderOffWhite>
+
           {this.renderCategories()}
 
           <View>

--- a/hedvig-app/src/components/dashboard/Offer.js
+++ b/hedvig-app/src/components/dashboard/Offer.js
@@ -53,7 +53,7 @@ class Offer extends React.Component {
             ))}
           </View>
           <OfferFooter insuranceType={this.props.insurance.insuranceType} />
-          <StyledPassiveText style={{paddingLeft: 24, paddingRight: 18, paddingBottom: 160}}>
+          <StyledPassiveText style={{paddingLeft: 24, paddingRight: 18, paddingBottom: 170}}>
             Genom att trycka bli medlem bekräftar jag att jag tagit del av&nbsp;
             <TextLink to={this.props.insurance.presaleInformationUrl}>förköpsinformation</TextLink>,
             Hedvigs <TextLink to={this.props.insurance.policyUrl}>försäkringsvillkor</TextLink> och att mina personuppgifter&nbsp;


### PR DESCRIPTION
The scroll area now covers the full view on home and profile, discussed this with Lucas.

Fix tap area on link to personuppgiftslagen (transparent background image was positioned above the text).

![img_0534](https://user-images.githubusercontent.com/20165/37820291-70d18c16-2e80-11e8-9e58-5e44e0458bae.png)
![img_0535](https://user-images.githubusercontent.com/20165/37820292-70e9e8b0-2e80-11e8-85ab-c86a7102f1c1.png)
