### PR TITLE
Fix peril icons not always loading in carousel

### DIFF
--- a/hedvig-app/App.js
+++ b/hedvig-app/App.js
@@ -1,53 +1,60 @@
-import "babel-polyfill"
-import React from "react"
-import { AppState, Keyboard, Platform } from "react-native"
-import { Provider } from "react-redux"
-import { Notifications } from "expo"
-import Sentry from "sentry-expo"
-import createRavenMiddleware from "raven-for-redux"
+import 'babel-polyfill';
+import React from 'react';
+import { AppState, Keyboard, Platform } from 'react-native';
+import { Provider } from 'react-redux';
+import { Notifications } from 'expo';
+import Sentry from 'sentry-expo';
+import createRavenMiddleware from 'raven-for-redux';
 import {
   ActionSheetProvider,
-  connectActionSheet
-} from "@expo/react-native-action-sheet"
-import * as hedvigRedux from "hedvig-redux"
-window.hedvigRedux = hedvigRedux
+  connectActionSheet,
+} from '@expo/react-native-action-sheet';
+import * as hedvigRedux from 'hedvig-redux';
+window.hedvigRedux = hedvigRedux;
 
-import { theme } from "hedvig-style"
-import nav from "./src/reducers/nav"
-import * as Navigation from "./src/services/Navigation"
-import { apiAndNavigateToChatSaga } from "./src/sagas/apiAndNavigate"
-import { tokenStorageSaga } from "./src/sagas/TokenStorage"
-import { logoutSaga } from "./src/sagas/logout"
-import { ThemeProvider } from "styled-components"
-import { Router } from "./src/components/navigation/Router"
-import { ErrorBoundary } from "./src/components/ErrorBoundary"
-import WithAssets from "./src/components/WithAssets"
-window.Navigation = Navigation
+import { theme } from 'hedvig-style';
+import nav from './src/reducers/nav';
+import * as Navigation from './src/services/Navigation';
+import { apiAndNavigateToChatSaga } from './src/sagas/apiAndNavigate';
+import { tokenStorageSaga } from './src/sagas/TokenStorage';
+import { logoutSaga } from './src/sagas/logout';
+import { ThemeProvider } from 'styled-components';
+import { Router } from './src/components/navigation/Router';
+import { ErrorBoundary } from './src/components/ErrorBoundary';
+import WithAssets from './src/components/WithAssets';
+window.Navigation = Navigation;
 
-import { appStateChange } from "./src/actions/appState"
-import { keyboardStateChange } from "./src/actions/keyboardState"
-import appStateChangeReducer from "./src/reducers/appState"
-import keyboardStateChangeReducer from "./src/reducers/keyboardState"
-import statusMessageReducer from "./src/reducers/statusMessage"
-import routerReducer from "./src/reducers/router"
-import { appStateSaga } from "./src/sagas/appState"
-import { keyboardSaga } from "./src/sagas/keyboard"
-import { navigationSaga } from "./src/sagas/navigation"
-import { requestPushSaga, registerPushSaga } from "./src/sagas/pushNotifications"
-import { chatStartSaga, chatLoginSaga } from "./src/sagas/marketingCarousel"
-import { getOrLoadToken } from "./src/services/TokenStorage"
-import * as baseNavigationActions from "./src/actions/baseNavigation"
-window.baseNavigation = baseNavigationActions
+import { appStateChange } from './src/actions/appState';
+import { keyboardStateChange } from './src/actions/keyboardState';
+import appStateChangeReducer from './src/reducers/appState';
+import keyboardStateChangeReducer from './src/reducers/keyboardState';
+import statusMessageReducer from './src/reducers/statusMessage';
+import routerReducer from './src/reducers/router';
+import { appStateSaga } from './src/sagas/appState';
+import { keyboardSaga } from './src/sagas/keyboard';
+import { navigationSaga } from './src/sagas/navigation';
+import {
+  requestPushSaga,
+  registerPushSaga,
+} from './src/sagas/pushNotifications';
+import { chatStartSaga, chatLoginSaga } from './src/sagas/marketingCarousel';
+import { getOrLoadToken } from './src/services/TokenStorage';
+import * as baseNavigationActions from './src/actions/baseNavigation';
+window.baseNavigation = baseNavigationActions;
 
-import navigationMiddleware from "./src/middleware/navigation"
+import navigationMiddleware from './src/middleware/navigation';
 
-Sentry.config("https://11b25670dab44c79bfd36ec805fda14a@sentry.io/271600").install()
+Sentry.config(
+  'https://11b25670dab44c79bfd36ec805fda14a@sentry.io/271600',
+).install();
 
-const ravenMiddleware = createRavenMiddleware(Sentry, {stateTransformer: state => ({user: state.user})})
+const ravenMiddleware = createRavenMiddleware(Sentry, {
+  stateTransformer: state => ({ user: state.user }),
+});
 
 export class App extends React.Component {
   constructor() {
-    super()
+    super();
     this.store = hedvigRedux.configureStore({
       additionalReducers: {
         nav,
@@ -66,70 +73,67 @@ export class App extends React.Component {
         chatStartSaga,
         chatLoginSaga,
         requestPushSaga,
-        registerPushSaga
+        registerPushSaga,
       ],
-      additionalMiddleware: [
-        navigationMiddleware,
-        ravenMiddleware
-      ],
-      raven: Sentry
-    })
-    window.store = this.store
+      additionalMiddleware: [navigationMiddleware, ravenMiddleware],
+      raven: Sentry,
+    });
+    window.store = this.store;
   }
 
   _handleAppStateChange = nextAppState => {
-    this.store.dispatch(appStateChange(nextAppState))
-  }
+    this.store.dispatch(appStateChange(nextAppState));
+  };
 
   _keyboardWillShow(event) {
-    this.store.dispatch(keyboardStateChange({ ...event, state: "shown" }))
+    this.store.dispatch(keyboardStateChange({ ...event, state: 'shown' }));
   }
 
   _keyboardWillHide(event) {
-    this.store.dispatch(keyboardStateChange({ ...event, state: "hidden" }))
+    this.store.dispatch(keyboardStateChange({ ...event, state: 'hidden' }));
   }
 
   componentDidMount() {
-    if (Platform.OS === "android") {
-      this.store.dispatch({type: "PUSH_NOTIFICATIONS/REGISTER_PUSH"})
+    if (Platform.OS === 'android') {
+      this.store.dispatch({ type: 'PUSH_NOTIFICATIONS/REGISTER_PUSH' });
     }
 
-    AppState.addEventListener("change", this._handleAppStateChange)
+    AppState.addEventListener('change', this._handleAppStateChange);
     this.keyboardWillShowListener = Keyboard.addListener(
-      Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow",
-      this._keyboardWillShow.bind(this)
-    )
+      Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow',
+      this._keyboardWillShow.bind(this),
+    );
     this.keyboardWillHideListener = Keyboard.addListener(
-      Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide",
-      this._keyboardWillHide.bind(this)
-    )
-    getOrLoadToken(this.store.dispatch)
+      Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide',
+      this._keyboardWillHide.bind(this),
+    );
+    getOrLoadToken(this.store.dispatch);
 
     this.store.dispatch(
       hedvigRedux.listenerActions.addListener(
         hedvigRedux.types.SHOW_ACTION_SHEET,
         ({ payload: { options, callback } }) =>
-          this.props.showActionSheetWithOptions(options, callback)
-      )
-    )
+          this.props.showActionSheetWithOptions(options, callback),
+      ),
+    );
 
-    this.store.dispatch(hedvigRedux.chatActions.getMessages())
-    this.store.dispatch(hedvigRedux.chatActions.getAvatars())
+    this.store.dispatch(hedvigRedux.chatActions.getMessages());
+    this.store.dispatch(hedvigRedux.chatActions.getAvatars());
 
-    Notifications.addListener(this._handleNotification)
+    Notifications.addListener(this._handleNotification);
   }
 
   _handleNotification = () => {
-    this.store.dispatch(hedvigRedux.chatActions.getMessages())
-  }
+    this.store.dispatch(hedvigRedux.chatActions.getMessages());
+  };
 
   componentWillUnmount() {
-    AppState.removeEventListener("change", this._handleAppStateChange)
+    AppState.removeEventListener('change', this._handleAppStateChange);
     if (this.keyboardWillShowListener) {
-      this.keyboardWillShowListener.remove()
+      this.keyboardWillShowListener.remove();
     }
     if (this.keyboardWillHideListener) {
-      this.keyboardWillHideListener.remove()
+      this.keyboardWillHideListener.remove();
     }
   }
 
@@ -144,22 +148,22 @@ export class App extends React.Component {
           </ThemeProvider>
         </WithAssets>
       </ErrorBoundary>
-    )
+    );
   }
 }
 
 export class AppWithActionSheet extends React.Component {
   constructor() {
-    super()
-    this.WrappedComponent = connectActionSheet(App)
+    super();
+    this.WrappedComponent = connectActionSheet(App);
   }
   render() {
     return (
       <ActionSheetProvider>
         <this.WrappedComponent />
       </ActionSheetProvider>
-    )
+    );
   }
 }
 
-export default AppWithActionSheet
+export default AppWithActionSheet;

--- a/hedvig-app/bump.js
+++ b/hedvig-app/bump.js
@@ -1,24 +1,24 @@
 /* global require */
-var fs = require("fs")
-var appJson = require("./app.json")
+var fs = require('fs');
+var appJson = require('./app.json');
 
 function parse(versionString) {
-  return versionString.split(".").map(s => parseInt(s, 10))
+  return versionString.split('.').map(s => parseInt(s, 10));
 }
 
 function bump(versionArray) {
-  versionArray[2] = versionArray[2] + 1
-  return versionArray
+  versionArray[2] = versionArray[2] + 1;
+  return versionArray;
 }
 
 function stringify(versionArray) {
-  return versionArray.map(i => i.toString()).join(".")
+  return versionArray.map(i => i.toString()).join('.');
 }
 
-appJson.expo.version = stringify(bump(parse(appJson.expo.version)))
+appJson.expo.version = stringify(bump(parse(appJson.expo.version)));
 appJson.expo.ios.buildNumber = stringify(
-  bump(parse(appJson.expo.ios.buildNumber))
-)
+  bump(parse(appJson.expo.ios.buildNumber)),
+);
 
-fs.writeFile("app.json", JSON.stringify(appJson, null, 2), () => {})
-console.log("Bumped app.json to version", appJson.expo.version) // eslint-disable-line no-console
+fs.writeFile('app.json', JSON.stringify(appJson, null, 2), () => {});
+console.log('Bumped app.json to version', appJson.expo.version); // eslint-disable-line no-console

--- a/hedvig-app/rn-cli.config.js
+++ b/hedvig-app/rn-cli.config.js
@@ -1,7 +1,8 @@
-const path = require("path")
+/* global __dirname module */
+const path = require('path');
 
 module.exports = {
   getProjectRoots() {
-    return [path.join(__dirname, ".."), __dirname]
-  }
-}
+    return [path.join(__dirname, '..'), __dirname];
+  },
+};

--- a/hedvig-app/src/components/Carousel.js
+++ b/hedvig-app/src/components/Carousel.js
@@ -1,23 +1,27 @@
-import React from 'react';
-import { View, Dimensions, BackHandler } from 'react-native';
-import { WebBrowser } from 'expo';
-import { default as SnapCarousel } from 'react-native-snap-carousel';
-import { connect } from 'react-redux';
-import { NavigationActions } from 'react-navigation';
+import React from "react"
+import {
+  View,
+  Dimensions,
+  BackHandler,
+  Image,
+} from "react-native"
+import { WebBrowser } from "expo"
+import { default as SnapCarousel } from "react-native-snap-carousel"
+import { connect } from "react-redux"
+import { NavigationActions } from "react-navigation"
 import {
   StyledCarouselContainer,
   StyledAlignedCarouselItems,
   StyledImageCarouselContainer,
-  StyledCarouselImage,
   StyledCarouselHeading,
   StyledCarouselTexts,
   StyledCarouselParagraph,
-  StyledParagraphToggleContainer,
-} from './styles/carousel';
-import { NavigateBackButton, TextButton } from './Button';
-import { NavBar } from './NavBar';
-const deviceWidth = Dimensions.get('window').width;
-const itemWidth = 186;
+  StyledParagraphToggleContainer
+} from "./styles/carousel"
+import { NavigateBackButton, TextButton } from "./Button"
+import { NavBar } from "./NavBar"
+const deviceWidth = Dimensions.get("window").width
+const perilContainerSize = 185
 
 class Carousel extends React.Component {
   navParams = this.props.navigation.state.params;
@@ -43,13 +47,18 @@ class Carousel extends React.Component {
 
   _renderItem({ item }) {
     return (
-      <StyledCarouselImage
-        source={item.imageUrl ? { uri: item.imageUrl } : item.itemSrc}
-        width={itemWidth}
-        height={itemWidth}
-        resizeMode="contain"
-      />
-    );
+      <View>
+        <Image
+          style={{
+            height: perilContainerSize,
+            width: perilContainerSize,
+          }}
+          source={item.itemSrc}
+          resizeMode="center"
+          key={item.id}
+        />
+      </View>
+    )
   }
 
   getItem() {
@@ -116,14 +125,13 @@ class Carousel extends React.Component {
         <StyledAlignedCarouselItems>
           <StyledImageCarouselContainer>
             <SnapCarousel
-              ref={c => {
-                this._carousel = c;
-              }}
               data={this.items}
               renderItem={this._renderItem}
               sliderWidth={deviceWidth}
-              itemWidth={itemWidth}
+              sliderHeight={perilContainerSize}
+              itemWidth={perilContainerSize}
               firstItem={this.state.slideIndex}
+              removeClippedSubviews={false} // removeClippedSubviews fixes an issue where the item is not always initially rendered
               onSnapToItem={slideIndex => {
                 this.setState({ slideIndex, showFullDescription: false });
               }}

--- a/hedvig-app/src/components/Carousel.js
+++ b/hedvig-app/src/components/Carousel.js
@@ -1,14 +1,9 @@
-import React from "react"
-import {
-  View,
-  Dimensions,
-  BackHandler,
-  Image,
-} from "react-native"
-import { WebBrowser } from "expo"
-import { default as SnapCarousel } from "react-native-snap-carousel"
-import { connect } from "react-redux"
-import { NavigationActions } from "react-navigation"
+import React from 'react';
+import { View, Dimensions, BackHandler, Image } from 'react-native';
+import { WebBrowser } from 'expo';
+import { default as SnapCarousel } from 'react-native-snap-carousel';
+import { connect } from 'react-redux';
+import { NavigationActions } from 'react-navigation';
 import {
   StyledCarouselContainer,
   StyledAlignedCarouselItems,
@@ -16,12 +11,12 @@ import {
   StyledCarouselHeading,
   StyledCarouselTexts,
   StyledCarouselParagraph,
-  StyledParagraphToggleContainer
-} from "./styles/carousel"
-import { NavigateBackButton, TextButton } from "./Button"
-import { NavBar } from "./NavBar"
-const deviceWidth = Dimensions.get("window").width
-const perilContainerSize = 185
+  StyledParagraphToggleContainer,
+} from './styles/carousel';
+import { NavigateBackButton, TextButton } from './Button';
+import { NavBar } from './NavBar';
+const deviceWidth = Dimensions.get('window').width;
+const perilContainerSize = 185;
 
 class Carousel extends React.Component {
   navParams = this.props.navigation.state.params;
@@ -58,7 +53,7 @@ class Carousel extends React.Component {
           key={item.id}
         />
       </View>
-    )
+    );
   }
 
   getItem() {

--- a/hedvig-app/src/components/dashboard/Peril.js
+++ b/hedvig-app/src/components/dashboard/Peril.js
@@ -1,18 +1,6 @@
 /* global require */
-<<<<<<< HEAD
 import React from 'react';
-import { TouchableOpacity } from 'react-native';
-import {
-  StyledPeril,
-  StyledPerilIcon,
-  StyledPerilTitle,
-} from '../styles/dashboard';
-=======
-import React from "react"
-import {
-  TouchableOpacity, Image, View, Text, StyleSheet
-} from "react-native"
->>>>>>> a4a86bd... Fix peril icons not always loading in carousel
+import { TouchableOpacity, Image, View, Text, StyleSheet } from 'react-native';
 
 const meLegalTrouble = require('../../../assets/icons/perils/perilIcos/jag_juridisk_tvist.png');
 const meAssault = require('../../../assets/icons/perils/perilIcos/jag_overfall.png');
@@ -75,26 +63,22 @@ const styles = StyleSheet.create({
   container: {
     width: 50,
     marginLeft: 22,
-    alignItems: "center"
+    alignItems: 'center',
   },
   icon: {
     width: 40,
     height: 40,
   },
   title: {
-    fontFamily: "circular",
+    fontFamily: 'circular',
     fontSize: 12,
-    color: "#9B9BAA",
-    textAlign: "center",
-  }
-})
+    color: '#9B9BAA',
+    textAlign: 'center',
+  },
+});
 
 export class Peril extends React.Component {
   render() {
-<<<<<<< HEAD
-    let peril = this.props.peril;
-=======
->>>>>>> a4a86bd... Fix peril icons not always loading in carousel
     return (
       <TouchableOpacity
         onPress={() =>
@@ -110,11 +94,11 @@ export class Peril extends React.Component {
         }
       >
         <View style={styles.container}>
-          <Image source={PERIL_IMAGE_MAP[this.props.peril.id]} style={styles.icon}>
-          </Image>
-          <Text style={styles.title}>
-            {this.props.peril.title}
-          </Text>
+          <Image
+            source={PERIL_IMAGE_MAP[this.props.peril.id]}
+            style={styles.icon}
+          />
+          <Text style={styles.title}>{this.props.peril.title}</Text>
         </View>
       </TouchableOpacity>
     );

--- a/hedvig-app/src/components/dashboard/Peril.js
+++ b/hedvig-app/src/components/dashboard/Peril.js
@@ -1,4 +1,5 @@
 /* global require */
+<<<<<<< HEAD
 import React from 'react';
 import { TouchableOpacity } from 'react-native';
 import {
@@ -6,6 +7,12 @@ import {
   StyledPerilIcon,
   StyledPerilTitle,
 } from '../styles/dashboard';
+=======
+import React from "react"
+import {
+  TouchableOpacity, Image, View, Text, StyleSheet
+} from "react-native"
+>>>>>>> a4a86bd... Fix peril icons not always loading in carousel
 
 const meLegalTrouble = require('../../../assets/icons/perils/perilIcos/jag_juridisk_tvist.png');
 const meAssault = require('../../../assets/icons/perils/perilIcos/jag_overfall.png');
@@ -64,9 +71,30 @@ const PERIL_IMAGE_MAP = {
   'STUFF.SUBLET.RENT.WEATHER': stuffWeather,
 };
 
+const styles = StyleSheet.create({
+  container: {
+    width: 50,
+    marginLeft: 22,
+    alignItems: "center"
+  },
+  icon: {
+    width: 40,
+    height: 40,
+  },
+  title: {
+    fontFamily: "circular",
+    fontSize: 12,
+    color: "#9B9BAA",
+    textAlign: "center",
+  }
+})
+
 export class Peril extends React.Component {
   render() {
+<<<<<<< HEAD
     let peril = this.props.peril;
+=======
+>>>>>>> a4a86bd... Fix peril icons not always loading in carousel
     return (
       <TouchableOpacity
         onPress={() =>
@@ -81,10 +109,13 @@ export class Peril extends React.Component {
           })
         }
       >
-        <StyledPeril>
-          <StyledPerilIcon source={PERIL_IMAGE_MAP[peril.id]} />
-          <StyledPerilTitle>{peril.title}</StyledPerilTitle>
-        </StyledPeril>
+        <View style={styles.container}>
+          <Image source={PERIL_IMAGE_MAP[this.props.peril.id]} style={styles.icon}>
+          </Image>
+          <Text style={styles.title}>
+            {this.props.peril.title}
+          </Text>
+        </View>
       </TouchableOpacity>
     );
   }

--- a/hedvig-app/src/components/dashboard/__snapshots__/Peril.test.js.snap
+++ b/hedvig-app/src/components/dashboard/__snapshots__/Peril.test.js.snap
@@ -5,13 +5,39 @@ exports[`<Peril /> Should render correctly 1`] = `
   activeOpacity={0.2}
   onPress={[Function]}
 >
-  <Styled(View)>
-    <Styled(Image)
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "marginLeft": 22,
+        "width": 50,
+      }
+    }
+  >
+    <Image
       source={1}
+      style={
+        Object {
+          "height": 40,
+          "width": 40,
+        }
+      }
     />
-    <Styled(Text)>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "color": "#9B9BAA",
+          "fontFamily": "circular",
+          "fontSize": 12,
+          "textAlign": "center",
+        }
+      }
+    >
       Juridisk tvist
-    </Styled(Text)>
-  </Styled(View)>
+    </Text>
+  </View>
 </TouchableOpacity>
 `;

--- a/hedvig-app/src/components/styles/carousel.js
+++ b/hedvig-app/src/components/styles/carousel.js
@@ -20,11 +20,14 @@ export const StyledImageCarouselContainer = styled.View`
   height: 185px;
 `;
 
+<<<<<<< HEAD
 export const StyledCarouselImage = styled.Image`
   height: 185px;
   width: ${props => props.width};
 `;
 
+=======
+>>>>>>> a4a86bd... Fix peril icons not always loading in carousel
 export const StyledCarouselHeading = MerriweatherFontText.extend`
   font-size: 24px;
   text-align: center;

--- a/hedvig-app/src/components/styles/carousel.js
+++ b/hedvig-app/src/components/styles/carousel.js
@@ -20,14 +20,6 @@ export const StyledImageCarouselContainer = styled.View`
   height: 185px;
 `;
 
-<<<<<<< HEAD
-export const StyledCarouselImage = styled.Image`
-  height: 185px;
-  width: ${props => props.width};
-`;
-
-=======
->>>>>>> a4a86bd... Fix peril icons not always loading in carousel
 export const StyledCarouselHeading = MerriweatherFontText.extend`
   font-size: 24px;
   text-align: center;

--- a/hedvig-app/src/components/styles/dashboard.js
+++ b/hedvig-app/src/components/styles/dashboard.js
@@ -1,5 +1,4 @@
-import styled from 'styled-components/native';
-import { StyledSmallPassiveText } from './text';
+import styled from "styled-components/native"
 
 export const StyledDashboardContainer = styled.View`
   flex: 1;
@@ -115,6 +114,7 @@ export const StyledCheckoutButton = styled.View`
   bottom: 32px;
 `;
 
+<<<<<<< HEAD
 export const StyledPeril = styled.View`
   width: 50px;
   margin-left: 22px;
@@ -130,6 +130,8 @@ export const StyledPerilIcon = styled.Image`
   height: 40px;
 `;
 
+=======
+>>>>>>> a4a86bd... Fix peril icons not always loading in carousel
 export const StyledConditionRow = styled.View`
   flex-direction: row;
   margin-bottom: 16px;

--- a/hedvig-app/src/components/styles/dashboard.js
+++ b/hedvig-app/src/components/styles/dashboard.js
@@ -1,4 +1,4 @@
-import styled from "styled-components/native"
+import styled from 'styled-components/native';
 
 export const StyledDashboardContainer = styled.View`
   flex: 1;
@@ -114,24 +114,6 @@ export const StyledCheckoutButton = styled.View`
   bottom: 32px;
 `;
 
-<<<<<<< HEAD
-export const StyledPeril = styled.View`
-  width: 50px;
-  margin-left: 22px;
-  align-items: center;
-`;
-
-export const StyledPerilTitle = StyledSmallPassiveText.extend`
-  text-align: center;
-`;
-
-export const StyledPerilIcon = styled.Image`
-  width: 40px;
-  height: 40px;
-`;
-
-=======
->>>>>>> a4a86bd... Fix peril icons not always loading in carousel
 export const StyledConditionRow = styled.View`
   flex-direction: row;
   margin-bottom: 16px;


### PR DESCRIPTION
Related to an issue with Flatlist used in react-native-snap-carousel:
https://github.com/archriss/react-native-snap-carousel/issues/145
https://github.com/facebook/react-native/issues/13316

Did some general cleanup to stop using styled components.