### PR TITLE
Allow multiline text input when chatting

### DIFF
--- a/hedvig-app/src/components/chat/ChatTextInput.js
+++ b/hedvig-app/src/components/chat/ChatTextInput.js
@@ -40,6 +40,7 @@ class ChatTextInput extends React.Component {
           underlineColorAndroid="transparent"
           onChangeText={text => onChange(message, text)}
           autoGrow
+          multiline
           returnKeyType="send"
           enablesReturnKeyAutomatically
           blurOnSubmit


### PR DESCRIPTION
Accidentally removed this setting from chat inputs a while back.